### PR TITLE
Migrate awards page to Next.js

### DIFF
--- a/assets/contacts.json
+++ b/assets/contacts.json
@@ -1,0 +1,25 @@
+[
+    {
+        "media": "Facebook",
+        "name": "ICS Student Council",
+        "src": "https://www.facebook.com/ICSStudentCouncil/"
+    },
+
+    {
+        "media": "Instagram",
+        "name": "@icssc.uci",
+        "src": "https://www.instagram.com/icssc.uci/"
+    },
+
+    {
+        "media": "Discord",
+        "name": "ICSSC",
+        "src": "https://discord.gg/c4t5dGcM9S"
+    },
+
+    {
+        "media": "Email",
+        "name": "icssc@uci.edu",
+        "src": "mailto:icssc@uci.edu"
+    }
+]

--- a/assets/data/awards.json
+++ b/assets/data/awards.json
@@ -1,0 +1,26 @@
+[
+    {
+        "name": "Awards",
+        "titles": [
+            "Most Outstanding Social/Support Organization",
+            "Student Alumni Engagement Sponsorship"
+        ],
+        "providers": [
+            "Anteater Awards 2011",
+            "Student Alumni Association"
+        ]
+    },
+
+    {
+        "name": "Recognitions",
+        "titles": [
+            "Third Place",
+            "Second Place"
+        ],
+        "providers": [
+            "Winter UCI Alumni Association Club Affiliates Challenge 2020",
+            "UCI Campus Organizations & Volunteer Programs | Love My Org Contest 2020"
+        ]
+
+    }
+]

--- a/pages/awards.js
+++ b/pages/awards.js
@@ -1,54 +1,33 @@
+import AwardsJSON from '../assets/data/awards.json';
+import { Container, Row, Col } from 'react-bootstrap';
+
+function Award(props) {
+  const {name, titles, providers} = props;
+  return (
+    <Container className="text-center">
+      <h2 className="h1">{name}</h2>
+      <Row lg={2}>
+        {Object.keys(titles).map((key, ind) => {
+          return (
+            <Col lg={6}>
+              <div key={ind}>
+                <h5 className="mt-3" key={titles}>{titles[key]}</h5>
+                <p key={providers}>{providers[key]}</p> 
+                </div>
+            </Col>
+          );
+        })}
+      </Row>
+    </Container>
+  )
+}
+
 export default function Awards() {
   return (
     <>
-      <h1 class="display-sm-4 display-lg-3">Awards & Recognitions</h1>
-
+      <h1>Awards & Recognitions</h1>
       <main role="main">
-        <section class="text-center bg-light u-content-space">
-          <div class="container">
-            <header class="text-center w-md-50 mx-auto mb-8">
-              <h2 class="h1">Awards</h2>
-            </header>
-
-            <div class="row">
-              <div class="col-lg-6 mb-5 mb-lg-0">
-                <h4 class="h5">Most Outstanding Social/Support Organization</h4>
-                <p class="mb-0">Anteater Awards 2011</p>
-              </div>
-
-              <div class="col-lg-6 mb-5 mb-lg-0">
-                <h4 class="h5">Student Alumni Engagement Sponsorship</h4>
-                <p class="mb-0">Student Alumni Association</p>
-              </div>
-            </div>
-          </div>
-        </section>
-
-        <section class="u-content-space">
-          <div class="container">
-            <header class="text-center w-md-50 mx-auto mb-8">
-              <h2 class="h1">Recognitions</h2>
-            </header>
-
-            <div class="row">
-              <div class="col-lg-6 text-center pl-lg-5">
-                <h2>2020</h2>
-              </div>
-
-              <div class="col-lg-6 text-center text-lg-left pl-lg-5">
-                <ul>
-                  <li>
-                    <p>3rd Place in Winter UCI Alumni Association Club Affiliates Challenge</p>
-                  </li>
-                  <li>
-                    <p>Second place in UCI Campus Organizations & Volunteer Programs I Love My Org contest</p>
-                  </li>
-                </ul>
-              </div>
-            </div>
-          </div>
-        </section>
-
+        {AwardsJSON.map(award => <Award {...award}/> )}
       </main>
     </>
   );

--- a/pages/committees.js
+++ b/pages/committees.js
@@ -1,5 +1,5 @@
-import CommitteesJSON from '../assets/data/committees.json'
-import {Container } from 'react-bootstrap';
+import CommitteesJSON from '../assets/data/committees.json';
+import { Container } from 'react-bootstrap';
 
 
 function Committee(props) {

--- a/pages/contacts.js
+++ b/pages/contacts.js
@@ -1,46 +1,28 @@
-import { FaFacebook, FaFacebookF } from "react-icons/fa";
+import ContactsJSON from '../assets/contacts.json';
+import { Row, Col } from 'react-bootstrap';
+
+function Contact(props) {
+  const {media, name, src} = props;
+  return (
+    <Col md={2}>
+      <h3 className="h5">{media}</h3>
+      <p className=""><a href={src}>{name}</a></p>
+    </Col>
+  )
+}
 
 export default function Contacts() {
   return (
     <>
-      <h1>Contact Us</h1>
+      <div>
+        <h1>Contact Us</h1>
+      </div>
       <main role="main">
-        <section class="container-fluid">
-          <div class="row text-center u-icon-block">
-            <div class="col-lg-3 u-icon-block__col">
-              <span class="u-icon u-icon-primary u-icon--size--xl rounded-circle mb-4">
-                <span class="fab fa-facebook u-icon__inner text-white"></span>
-              </span>
-              <h3 class="h5">Facebook</h3>
-              <p class="mb-0"><a href="https://www.facebook.com/ICSStudentCouncil/">ICS Student Council</a></p>
-            </div>
-
-            <div class="col-lg-3 u-icon-block__col u-icon-block__col--left-brd">
-              <span class="u-icon u-icon-primary u-icon--size--xl rounded-circle mb-4">
-                <span class="fab fa-instagram u-icon__inner text-white"></span>
-              </span>
-              <h3 class="h5">Instagram</h3>
-              <p class="mb-0"><a href="https://www.instagram.com/icssc.uci/">@icssc.uci</a></p>
-            </div>
-
-            <div class="col-lg-3 u-icon-block__col u-icon-block__col--left-brd">
-              <span class="u-icon u-icon-primary u-icon--size--xl rounded-circle mb-4">
-                <span class="fab fa-discord u-icon__inner text-white"></span>
-              </span>
-              <h3 class="h5">Discord</h3>
-              <p class="mb-0"><a href="https://discord.gg/c4t5dGcM9S">ICSSC</a></p>
-            </div>
-
-            <div class="col-lg-3 u-icon-block__col u-icon-block__col--left-brd">
-              <span class="u-icon u-icon-primary u-icon--size--xl rounded-circle mb-4">
-                <span class="fas fa-envelope-open u-icon__inner text-white"></span>
-              </span>
-              <h3 class="h5">Email</h3>
-              <p class="mb-0"><a href="mailto:icssc@uci.edu">icssc@uci.edu</a></p>
-            </div>
-          </div>
-        </section>
+        <Row className="text-center justify-content-sm-center">
+          {ContactsJSON.map(contact => <Contact {...contact}/>)}
+        </Row>
       </main>
+      
     </>
   )
 }


### PR DESCRIPTION
closes #24 

- Changed awards.js to Next.js
- Added awards.json
- Changed layout for recognitions. No longer groups by year
- Use React-Bootstrap for responsiveness

### Additional comments
JSON page may not be the best representation for the data. May require multiple json files (awards, recognition) as the data grows. Not a lot of data to display currently, so a single json file could work

### Page Preview
![image](https://user-images.githubusercontent.com/65209258/180578518-1fc4d927-5ed8-4de8-8236-54d9c21fcfb3.png)
![image](https://user-images.githubusercontent.com/65209258/180578586-3f79746a-0606-4ff0-a9dd-004507db2477.png)
